### PR TITLE
Fix bin config in package.json

### DIFF
--- a/bin/builddocs.js
+++ b/bin/builddocs.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var fs = require("fs")
 
 var build = require("../src/builddocs").build

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     }
   ],
   "license": "MIT",
+  "bin": {
+    "builddocs": "./bin/builddocs.js"
+  },
   "bugs": {
     "url": "https://github.com/marijnh/builddocs/issues"
   },


### PR DESCRIPTION
Closes #1 

Currently this module is not exposed as binary, which leads to error when running it with npm scripts like `"build_demo": "builddocs"`. To fix this we can simply add shebang in `./bin` with `bin` entry in package.json. This configuration is tested in these cases:

* Using `"builddocs"` in npm scripts does not throw error.
* `npm link` in source dir and we can use `builddocs` via terminal command.
* Running `node ./bin/builddocs.js` remains intact.

See also package.json [docs](https://docs.npmjs.com/files/package.json#bin).