### PR TITLE
Don't try to link type params

### DIFF
--- a/templates/class.html
+++ b/templates/class.html
@@ -3,7 +3,7 @@
 <h4 id="<<t prefix + item.id>>">
   <span class=kind><<if item.abstract>>abstract <</if>><<t item.type>></span>
   <a href="#<<t prefix + item.id>>"><<t name>></a>
-  <<if item.typeParams>>&lt;<<for elt item.typeParams>><<if $i>>, <</if>><<type elt>><</for>>&gt;<</if>>
+  <<if item.typeParams>>&lt;<<for elt item.typeParams>><<if $i>>, <</if>><<t elt.type>><</for>>&gt;<</if>>
   <<if item.extends>> <span class=extends>extends <code><<type item.extends>></code></span><</if>>
   <<if item.implements>> <span class=implements>implements <code><<type item.implements>></code></span><</if>>
 </h4>

--- a/templates/fntype.html
+++ b/templates/fntype.html
@@ -1,4 +1,4 @@
-<<if $in.typeParams>>&lt;<<for elt $in.typeParams>><<if $i>>, <</if>><<type elt>><</for>>&gt;<</if>>
+<<if $in.typeParams>>&lt;<<for elt $in.typeParams>><<if $i>>, <</if>><<t elt.type>><</for>>&gt;<</if>>
 (<<for param $in.params || []>>
   <<if $i>>, <</if>><<if param.rest>>...<</if>>
   <<if param.name>><span class=param><<t param.name>>:</span> <</if>>

--- a/templates/type.html
+++ b/templates/type.html
@@ -16,7 +16,7 @@
     <<if !hasDescription(prop)>><<if needComma>>, <</if>><span class=prop><<t name>>: </span><<type prop>><<do needComma = true>><</if>>
    <</for>>}
 <<else>>
-  <<do var found = linkType($in)
+  <<do var found = !$in.typeParamUsage && !$in.literal && linkType($in)
        var cls = /^"/.test($in.type) ? "string" : /(^|\.)[A-Z]\w+$/.test($in.type) ? "type" : "prim" >>
   <<if found>><a href="<<t found>>"><</if>>
     <span class="<<t cls>>"><<t $in.type>></span>


### PR DESCRIPTION
This introduces a new property `typeParamUsage` to mark the second `V` in `function<V> (v: V)` as a type parameter and not try to link it. Alternatively, builddocs could keep track of type params in the current scope and do this work itself.